### PR TITLE
Add build logic to pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,10 @@ jobs:
         java-package: jdk
         architecture: x64
     
+    - name: Set Permissions on scripts.
+      run: chmod u+x *.sh
+
+
     # Runs a single command using the runners shell
     - name: Build Source Classes
       run: ./build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
         architecture: x64
     
     # Runs a single command using the runners shell
-    - name: Run a one-line script
-      run: echo Hello, world!
+    - name: Build Source Classes
+      run: ./build.sh
 
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p cp
+javac ./SkunkProject/src/*.java -classpath ./SkunkProject/lib/stdlib.jar:./SkunkProject/lib/stdlib-package.jar -d cp


### PR DESCRIPTION
Added ./build.sh which compiles `*.java` classes in the `src` directory.
Modified the actions in the pipeline to execute ./build.sh.

`./build.sh` lacked the execute bit in the file permissions.
this caused a build failure when pushed to github.